### PR TITLE
Add Fortigate as new vendor.

### DIFF
--- a/config.c
+++ b/config.c
@@ -477,7 +477,7 @@ static const struct config_names_s {
 		CONFIG_VENDOR, 1, 0, 1,
 		"--vendor",
 		"Vendor",
-		"<cisco/netscreen>",
+		"<cisco/netscreen/fortigate>",
 		"vendor of your IPSec gateway",
 		config_def_vendor
 	}, {
@@ -973,8 +973,10 @@ void do_config(int argc, char **argv)
 			opt_vendor = VENDOR_CISCO;
 		} else if (!strcmp(config[CONFIG_VENDOR], "netscreen")) {
 			opt_vendor = VENDOR_NETSCREEN;
+		} else if (!strcmp(config[CONFIG_VENDOR], "fortigate")) {
+			opt_vendor = VENDOR_FORTIGATE;
 		} else {
-			printf("%s: unknown vendor %s\nknown vendors: cisco netscreen\n", argv[0], config[CONFIG_VENDOR]);
+			printf("%s: unknown vendor %s\nknown vendors: cisco netscreen fortigate\n", argv[0], config[CONFIG_VENDOR]);
 			exit(1);
 		}
 	}

--- a/config.h
+++ b/config.h
@@ -71,7 +71,8 @@ enum hex_dump_enum {
 
 enum vendor_enum {
 	VENDOR_CISCO,
-	VENDOR_NETSCREEN
+	VENDOR_NETSCREEN,
+	VENDOR_FORTIGATE
 };
 
 enum natt_mode_enum {

--- a/vpnc.c
+++ b/vpnc.c
@@ -1203,7 +1203,8 @@ static void lifetime_ike_process(struct sa_block *s, struct isakmp_attribute *a)
 	assert(a->af == isakmp_attr_16);
 	assert(a->u.attr_16 == IKE_LIFE_TYPE_SECONDS || a->u.attr_16 == IKE_LIFE_TYPE_K);
 	assert(a->next != NULL);
-	assert(a->next->type == IKE_ATTRIB_LIFE_DURATION);
+	if (opt_vendor != VENDOR_FORTIGATE)
+		assert(a->next->type == IKE_ATTRIB_LIFE_DURATION);
 
 	if (a->next->af == isakmp_attr_16)
 		value = a->next->u.attr_16;
@@ -1305,7 +1306,7 @@ static void do_phase1_am_packet1(struct sa_block *s, const char *key_id)
 		l = l->next->next;
 		l->next = new_isakmp_payload(ISAKMP_PAYLOAD_ID);
 		l = l->next;
-		if (opt_vendor == VENDOR_CISCO)
+		if (opt_vendor == VENDOR_CISCO || opt_vendor == VENDOR_FORTIGATE)
 			l->u.id.type = ISAKMP_IPSEC_ID_KEY_ID;
 		else
 			l->u.id.type = ISAKMP_IPSEC_ID_USER_FQDN;
@@ -3239,7 +3240,7 @@ int main(int argc, char **argv)
 		if (s->ike.auth_algo >= IKE_AUTH_HybridInitRSA)
 			do_load_balance = do_phase2_xauth(s);
 		DEBUGTOP(2, printf("S6 do_phase2_config\n"));
-		if ((opt_vendor == VENDOR_CISCO) && (do_load_balance == 0))
+		if ((opt_vendor == VENDOR_CISCO || opt_vendor == VENDOR_FORTIGATE) && (do_load_balance == 0))
 			do_load_balance = do_phase2_config(s);
 	} while (do_load_balance);
 	DEBUGTOP(2, printf("S7 setup_link (phase 2 + main_loop)\n"));


### PR DESCRIPTION
Implements change from http://rolandtapken.de/blog/2015-06/how-connect-fortigate-ipsec-vpn-using-linux by adding `fortigate` as a new vendor, rather than simply commenting line 1206 in vpnc.c

Signed-off-by: mattflax <matt@flax.co.uk>