### PR TITLE
bugfix: restore original cwd after vpnc_main_loop()

### DIFF
--- a/src/tunip.c
+++ b/src/tunip.c
@@ -1067,6 +1067,7 @@ void vpnc_doit(struct sa_block *s)
 	struct encap_method meth;
 
 	const char *pidfile = config[CONFIG_PID_FILE];
+	const char *cwd;
 
 	switch (s->ipsec.encap_mode) {
 	case IPSEC_ENCAP_TUNNEL:
@@ -1120,6 +1121,8 @@ void vpnc_doit(struct sa_block *s)
 	signal(SIGINT, killit);
 	signal(SIGTERM, killit);
 
+	/* save cwd */
+	cwd = get_current_dir_name();
 	chdir("/");
 
 	if (!opt_nd) {
@@ -1148,6 +1151,10 @@ void vpnc_doit(struct sa_block *s)
 	write_pidfile(pidfile);
 
 	vpnc_main_loop(s);
+
+	/* restore cwd */
+	chdir(cwd);
+	free(cwd);
 
 	if (pidfile)
 		unlink(pidfile); /* ignore errors */


### PR DESCRIPTION
In brief, the pre-fork chdir() causes the vpnc-script to be executed in a
different environment upon disconnect than upon connect.

This causes `--script ../relative/path/to/vpnc-script` to silently
fail to invoke the disconnect hook.

See this post from the upstream mailing list: http://lists.unix-ag.uni-kl.de/pipermail/vpnc-devel/2016-August/004199.html

(already accepted by Debian and Ubuntu, e.g. https://bugs.launchpad.net/ubuntu/+source/vpnc/+bug/1612100)