### PR TITLE
replace syslog() with vsyslog()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -76,7 +76,7 @@ extern void logmsg(int priority, const char *format, ...)
 	va_list ap;
 	va_start(ap, format);
 	if (!opt_nd) {
-		syslog(priority, format, ap);
+		vsyslog(priority, format, ap);
 	} else {
 		fprintf(stderr, "vpnc: ");
 		vfprintf(stderr, format, ap);


### PR DESCRIPTION
To pass `va_list ap` we need to call vsyslog().

With 9c38223cc83fd785d5f1b948b354aa7838a84d0e I had invalid syslog output like:

```
vpnc[18062]: terminated by signal: -2067153808
```