### PR TITLE
remove install-scripts in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,16 +145,7 @@ install-doc:
 	install -m644 src/doc/*.md $(DESTDIR)$(DOCDIR)
 	rm -f $(DESTDIR)$(DOCDIR)/Home.md
 
-install-scripts:
-	git submodule update --init src/scripts
-	if [ "`uname -s | cut -c-6`" = "CYGWIN" ]; then \
-		install src/scripts/vpnc-script-win $(DESTDIR)$(ETCDIR)/vpnc-script; \
-		install src/scripts/vpnc-script-win.js $(DESTDIR)$(ETCDIR); \
-	else \
-		install src/scripts/vpnc-script $(DESTDIR)$(ETCDIR); \
-	fi
-
-install: install-common install-scripts install-doc
+install: install-common install-doc
 	install -m755 $(BUILDDIR)/vpnc $(DESTDIR)$(SBINDIR)
 	install -m755 $(BUILDDIR)/cisco-decrypt $(DESTDIR)$(BINDIR)
 


### PR DESCRIPTION
vpnc-scripts is remove in 840a05befb518091f70a40673bdc6a825a0f132c

I also have a question about install `vpnc-scripts`.
because `vpnc-scripts` is removed in 840a05befb518091f70a40673bdc6a825a0f132c,
we need to install it manually as follow, is my understanding correct?

```bash
git clone git://git.infradead.org/users/dwmw2/vpnc-scripts.git
cd vpnc-scripts
sudo cp vpnc-script /etc/vpnc
```