### PR TITLE
Revert "src: vpnc: fix dead peer detection"

### DIFF
--- a/src/vpnc.c
+++ b/src/vpnc.c
@@ -797,9 +797,7 @@ void dpd_ike(struct sa_block *s)
 		*/
 		s->ike.dpd_attempts = 6;
 		s->ike.dpd_sent = time(NULL);
-		s->ike.dpd_seqno = ntohl(s->ike.dpd_seqno);
 		s->ike.dpd_seqno++;
-		s->ike.dpd_seqno = htonl(s->ike.dpd_seqno);
 		send_dpd(s, 0, s->ike.dpd_seqno);
 	} else {
 		/* Our last dpd request has not yet been acked.  If it's been
@@ -1609,7 +1607,6 @@ static void do_phase1_am_packet2(struct sa_block *s, const char *shared_key)
 					if (s->ike.dpd_idle != 0) {
 						gcry_create_nonce(&s->ike.dpd_seqno, sizeof(s->ike.dpd_seqno));
 						s->ike.dpd_seqno &= 0x7FFFFFFF;
-						s->ike.dpd_seqno = htonl(s->ike.dpd_seqno);
 						s->ike.dpd_seqno_ack = s->ike.dpd_seqno;
 						s->ike.do_dpd = 1;
 						DEBUG(2, printf("peer is DPD capable (RFC3706)\n"));


### PR DESCRIPTION
This reverts commit 556fde66ce4841e9bec09a2c6fe1b2d9fa09f8b6.

The exact same patch was already committed upstream (as f84730fb664c9 in
this repo), and subsequently modified in 2287ff81e54a and cb42fb32f

As described in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954356,
by applying this patch *again* the issue is reintroduced instead of fixed!