### PR TITLE
vpnc@.service: fix path to vpnc binary and add a few protections

### DIFF
--- a/src/vpnc@.service
+++ b/src/vpnc@.service
@@ -7,12 +7,23 @@ After=network.target
 
 [Service]
 Type=forking
-ExecStart=/usr/bin/vpnc --pid-file=/run/vpnc@%i.pid /etc/vpnc/%i.conf
+ExecStart=/usr/sbin/vpnc --pid-file=/run/vpnc@%i.pid /etc/vpnc/%i.conf
 ExecStartPre=-/etc/vpnc/scripts.d/%i-preup.sh
 ExecStartPost=-/etc/vpnc/scripts.d/%i-postup.sh
 ExecStopPost=-/etc/vpnc/scripts.d/%i-postdown.sh
 PIDFile=/run/vpnc@%i.pid
 Restart=always
+
+NoNewPrivileges=yes
+RestrictRealtime=yes
+ProtectHome=yes
+InaccessiblePaths=/home
+PrivateTmp=yes
+MemoryDenyWriteExecute=yes
+RestrictNamespaces=yes
+RemoveIPC=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
protections suggested Simon Brand <simon.brand@postadigitale.de> via
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=935855

(As Makefile installs vpnc into SBINDIR, I wonder if this ExecStart has
ever been used?!)