### PR TITLE
pcf2vpnc: Use canonical shebang for perl

### DIFF
--- a/src/pcf2vpnc
+++ b/src/pcf2vpnc
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 # Stefan Tomanek <stefan@pico.ruhr.de>
 # updated by Wolfram Sang <ninja@the-dreams.de> on 21.10.06 and on 26.06.07
 ##


### PR DESCRIPTION
Debian has this policy that Perl scripts shipped as part of distribution packages must work with the system Perl and hence should reference the system Perl in their shebang line - so as to keep working even if an incompatible Perl has been installed in the user environment.

I'm not sure how other distributions look at this, so I've separated this one out from the other Debian patches.