### PR TITLE
Use pkg-config to find libgcrypt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,10 @@ export VERSION
 CC ?= gcc
 CFLAGS ?= -O3 -g
 CFLAGS += -W -Wall -Wmissing-declarations -Wwrite-strings
-CFLAGS +=  $(shell libgcrypt-config --cflags) $(CRYPTO_CFLAGS)
+CFLAGS +=  $(shell $(PKG_CONFIG) --cflags libgcrypt) $(CRYPTO_CFLAGS)
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -DSCRIPT_PATH=\"$(SCRIPT_PATH)\"
 LDFLAGS ?= -g
-LIBS += $(shell libgcrypt-config --libs) $(CRYPTO_LDADD)
+LIBS += $(shell $(PKG_CONFIG) --libs libgcrypt) $(CRYPTO_LDADD)
 VPNC ?= $(BUILDDIR)/vpnc
 
 ifeq ($(shell uname -s), SunOS)


### PR DESCRIPTION
In [Nixpkgs](1), when cross-compiling, programs from packages for the architecture the program is being built for are not available in `PATH`, so finding libgcrypt-config would fail.  Using pkg-config solves this problem, because we can use the build architecture's pkg-config.

I think this is a worthwhile change to make upstream because pkg-config is already being used for finding gnutls, so it makes sense to standardize.  I don't know for sure, but I imagine dealing with pkg-config is nicer than custom -config scripts for other distributions too.

[1]: https://github.com/NixOS/nixpkgs
