### PR TITLE
Don't fetch doc submodule if it's already present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,10 @@ install-common: all
 	install -m644 src/vpnc@.service -t $(DESTDIR)$(SYSTEMDDIR)
 	install -m644 LICENSE $(DESTDIR)$(LICENSEDIR)
 
-install-doc:
+src/doc:
 	git submodule update --init src/doc
+
+install-doc: src/doc
 	install -m644 src/doc/*.md $(DESTDIR)$(DOCDIR)
 	rm -f $(DESTDIR)$(DOCDIR)/Home.md
 


### PR DESCRIPTION
In [Nix](1), networking is not allowed during builds, and fetching sources has to be done up front, to ensure reproducibility.  It's easy for us to fetch the doc submodule up front as well as the main repository, but the build would still fail, because the install-doc make target would unconditionally try to fetch the submodule anyway.  (Additionally, this forced a dependency on git which would otherwise be unnecessary.)

To fix this, I've modified the Makefile so that it'll only try to fetch the submodule if src/doc doesn't already exist.  This is a slight behaviour change, because previously running make install-doc would update the submodule, but I think that's okay, because as I user I wouldn't expect make install to download anything.

[1]: https://nixos.org/
