### PR TITLE
Fall back to libgcrypt-config if pkg-config doesn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,10 @@ export VERSION
 CC ?= gcc
 CFLAGS ?= -O3 -g
 CFLAGS += -W -Wall -Wmissing-declarations -Wwrite-strings
-CFLAGS +=  $(shell $(PKG_CONFIG) --cflags libgcrypt) $(CRYPTO_CFLAGS)
+CFLAGS +=  $(shell $(PKG_CONFIG) --cflags libgcrypt || libgcrypt-config --cflags) $(CRYPTO_CFLAGS)
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -DSCRIPT_PATH=\"$(SCRIPT_PATH)\"
 LDFLAGS ?= -g
-LIBS += $(shell $(PKG_CONFIG) --libs libgcrypt) $(CRYPTO_LDADD)
+LIBS += $(shell $(PKG_CONFIG) --libs libgcrypt || libgcrypt-config --libs) $(CRYPTO_LDADD)
 VPNC ?= $(BUILDDIR)/vpnc
 
 ifeq ($(shell uname -s), SunOS)


### PR DESCRIPTION
During my testing, I found out that the pkg-config method to retrieve
the libgcrypt CFLAGS and LIBS does not work in some cases.
At least when cross-compiling for OpenWRT on ARM, pkg-config errors
with the message

> Package libgcrypt was not found in the pkg-config search path.
> Perhaps you should add the directory containing `libgcrypt.pc'
> to the PKG_CONFIG_PATH environment variable
> No package 'libgcrypt' found

As a consequence, vpnc cannot compile due to non-resolvable libgcrypt
dependencies and the build fails.

Now, we fall back to the old method of using the libgcrypt-config
script if pkg-config cannot retrieve the libgcrypt configurations.

See #23