### PR TITLE
Fix config.c

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -892,7 +892,7 @@ void do_config(int argc, char **argv)
 			if (known) {
 				if (config_names[c].needsEncryption) {
 					int field_len = strlen(argv[i]);
-					char *field = malloc(field_len * sizeof(char));
+					char *field = malloc((field_len + 1) * sizeof(char));
 					strcpy(field, argv[i]);
 					config[config_names[c].nm] = field;
 					rand_str(argv[i], field_len);

--- a/src/config.c
+++ b/src/config.c
@@ -682,7 +682,7 @@ static char *get_config_filename(const char *name, int add_dot_conf)
 {
 	char *realname;
 
-	asprintf(&realname, "%s%s%s", index(name, '/') ? "" : "/etc/vpnc/", name, add_dot_conf ? ".conf" : "");
+	asprintf(&realname, "%s%s%s", strchr(name, '/') ? "" : "/etc/vpnc/", name, add_dot_conf ? ".conf" : "");
 	return realname;
 }
 


### PR DESCRIPTION
These are two commits that
* replace `index()` by `strchr()` and
* allocate an extra byte for the terminating `\0` to prevent a possible segfault in the `strcpy()` call that follows `malloc()`.

Please see the descriptions of the commits for further explanations.