### PR TITLE
Amend cross compilation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,12 @@ SYSTEMDDIR=$(PREFIX)/lib/systemd/system
 #OPENSSL_GPL_VIOLATION=yes
 
 PKG_CONFIG ?= pkg-config
+
+ifneq ($(OPENSSL_GPL_VIOLATION), yes)
 CRYPTO_LDADD = $(shell $(PKG_CONFIG) --libs gnutls)
 CRYPTO_CFLAGS = $(shell $(PKG_CONFIG) --cflags gnutls) -DCRYPTO_GNUTLS
 CRYPTO_SRCS = src/crypto-gnutls.c
-
-ifeq ($(OPENSSL_GPL_VIOLATION), yes)
+else
 CRYPTO_LDADD = -lcrypto
 CRYPTO_CFLAGS = -DOPENSSL_GPL_VIOLATION -DCRYPTO_OPENSSL
 CRYPTO_SRCS = src/crypto-openssl.c

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ SYSTEMDDIR=$(PREFIX)/lib/systemd/system
 #OPENSSL_GPL_VIOLATION=yes
 
 PKG_CONFIG ?= pkg-config
+LIBGCRYPT_CONFIG ?= libgcrypt-config
+LIBGCRYPT_LDADD = $(shell $(PKG_CONFIG) --libs libgcrypt || $(LIBGCRYPT_CONFIG) --libs)
+LIBGCRYPT_CFLAGS = $(shell $(PKG_CONFIG) --cflags libgcrypt || $(LIBGCRYPT_CONFIG) --cflags)
 
 ifneq ($(OPENSSL_GPL_VIOLATION), yes)
 CRYPTO_LDADD = $(shell $(PKG_CONFIG) --libs gnutls)
@@ -74,10 +77,10 @@ export VERSION
 CC ?= gcc
 CFLAGS ?= -O3 -g
 CFLAGS += -W -Wall -Wmissing-declarations -Wwrite-strings
-CFLAGS +=  $(shell $(PKG_CONFIG) --cflags libgcrypt || libgcrypt-config --cflags) $(CRYPTO_CFLAGS)
+CFLAGS += $(LIBGCRYPT_CFLAGS) $(CRYPTO_CFLAGS)
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -DSCRIPT_PATH=\"$(SCRIPT_PATH)\"
 LDFLAGS ?= -g
-LIBS += $(shell $(PKG_CONFIG) --libs libgcrypt || libgcrypt-config --libs) $(CRYPTO_LDADD)
+LIBS += $(LIBGCRYPT_LDADD) $(CRYPTO_LDADD)
 VPNC ?= $(BUILDDIR)/vpnc
 
 ifeq ($(shell uname -s), SunOS)

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@
 #
 # $Id$
 
-DESTDIR=
-PREFIX=/usr/local
+PREFIX?=/usr/local
 ETCDIR=/etc/vpnc
 BINDIR=$(PREFIX)/bin
 SBINDIR=$(PREFIX)/sbin


### PR DESCRIPTION
Two commits further improve cross compilation support by
* making `libgcrypt-config` substitutable similar to `pkg-config` and
* allowing to override `$PREFIX` and `$DESTDIR` from the command line.

The other commit guards the query to `pkg-config` for gnutls if you want to compile with OpenSSL's crypto instead.