### PR TITLE
Avoid weak cryptography

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -48,7 +48,7 @@ const char charset[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:?()/%@!$";
 
 int opt_debug = 0;
 int opt_nd;
-int opt_weak_encryption, opt_no_encryption, opt_auth_mode;
+int opt_weak_encryption, opt_no_encryption, opt_weak_authentication, opt_auth_mode;
 enum natt_mode_enum opt_natt_mode;
 enum vendor_enum opt_vendor;
 enum if_mode_enum opt_if_mode;
@@ -549,6 +549,13 @@ static const struct config_names_s {
 		"enables using no encryption for data traffic (key exchanged must be encrypted)",
 		NULL
 	}, {
+		CONFIG_ENABLE_WEAK_AUTHENTICATION, 0, 0, 1,
+		"--enable-weak-authentication",
+		"Enable weak authentication",
+		NULL,
+		"enables weak authentication methods (such as MD5)",
+		NULL
+	}, {
 		CONFIG_VERSION, 1, 0, 1,
 		"--application-version",
 		"Application version",
@@ -948,6 +955,7 @@ void do_config(int argc, char **argv)
 		opt_debug = (config[CONFIG_DEBUG]) ? atoi(config[CONFIG_DEBUG]) : 0;
 		opt_nd = (config[CONFIG_ND]) ? 1 : 0;
 		opt_weak_encryption = (config[CONFIG_ENABLE_WEAK_ENCRYPTION]) ? 1 : 0;
+		opt_weak_authentication = (config[CONFIG_ENABLE_WEAK_AUTHENTICATION]) ? 1 : 0;
 
 		if (!strcmp(config[CONFIG_AUTH_MODE], "psk")) {
 			opt_auth_mode = AUTH_MODE_PSK;

--- a/src/config.c
+++ b/src/config.c
@@ -48,7 +48,7 @@ const char charset[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:?()/%@!$";
 
 int opt_debug = 0;
 int opt_nd;
-int opt_1des, opt_no_encryption, opt_auth_mode;
+int opt_weak_encryption, opt_no_encryption, opt_auth_mode;
 enum natt_mode_enum opt_natt_mode;
 enum vendor_enum opt_vendor;
 enum if_mode_enum opt_if_mode;
@@ -528,11 +528,18 @@ static const struct config_names_s {
 		"Diffie-Hellman group to use for PFS",
 		config_def_pfs
 	}, {
-		CONFIG_ENABLE_1DES, 0, 0, 1,
+		CONFIG_ENABLE_WEAK_ENCRYPTION, 0, 0, 1,
 		"--enable-1des",
 		"Enable Single DES",
 		NULL,
-		"enables weak single DES encryption",
+		"Deprecated: Please use --enable-weak-encryption instead.",
+		NULL
+	}, {
+		CONFIG_ENABLE_WEAK_ENCRYPTION, 0, 0, 1,
+		"--enable-weak-encryption",
+		"Enable weak encryption",
+		NULL,
+		"enables weak encryption methods (such as DES, 3DES)",
 		NULL
 	}, {
 		CONFIG_ENABLE_NO_ENCRYPTION, 0, 0, 1,
@@ -940,7 +947,7 @@ void do_config(int argc, char **argv)
 
 		opt_debug = (config[CONFIG_DEBUG]) ? atoi(config[CONFIG_DEBUG]) : 0;
 		opt_nd = (config[CONFIG_ND]) ? 1 : 0;
-		opt_1des = (config[CONFIG_ENABLE_1DES]) ? 1 : 0;
+		opt_weak_encryption = (config[CONFIG_ENABLE_WEAK_ENCRYPTION]) ? 1 : 0;
 
 		if (!strcmp(config[CONFIG_AUTH_MODE], "psk")) {
 			opt_auth_mode = AUTH_MODE_PSK;

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@ enum config_enum {
 	CONFIG_DOMAIN,
 	CONFIG_ENABLE_WEAK_ENCRYPTION,
 	CONFIG_ENABLE_NO_ENCRYPTION,
+	CONFIG_ENABLE_WEAK_AUTHENTICATION,
 	CONFIG_ND,
 	CONFIG_NON_INTERACTIVE,
 	CONFIG_PID_FILE,
@@ -100,7 +101,7 @@ extern const char *config[LAST_CONFIG];
 extern enum vendor_enum opt_vendor;
 extern int opt_debug;
 extern int opt_nd;
-extern int opt_weak_encryption, opt_no_encryption, opt_auth_mode;
+extern int opt_weak_encryption, opt_no_encryption, opt_weak_authentication, opt_auth_mode;
 extern enum natt_mode_enum opt_natt_mode;
 extern enum if_mode_enum opt_if_mode;
 extern uint16_t opt_udpencapport;

--- a/src/config.h
+++ b/src/config.h
@@ -30,7 +30,7 @@ enum config_enum {
 	CONFIG_SCRIPT,
 	CONFIG_DEBUG,
 	CONFIG_DOMAIN,
-	CONFIG_ENABLE_1DES,
+	CONFIG_ENABLE_WEAK_ENCRYPTION,
 	CONFIG_ENABLE_NO_ENCRYPTION,
 	CONFIG_ND,
 	CONFIG_NON_INTERACTIVE,
@@ -100,7 +100,7 @@ extern const char *config[LAST_CONFIG];
 extern enum vendor_enum opt_vendor;
 extern int opt_debug;
 extern int opt_nd;
-extern int opt_1des, opt_no_encryption, opt_auth_mode;
+extern int opt_weak_encryption, opt_no_encryption, opt_auth_mode;
 extern enum natt_mode_enum opt_natt_mode;
 extern enum if_mode_enum opt_if_mode;
 extern uint16_t opt_udpencapport;

--- a/src/vpnc.c
+++ b/src/vpnc.c
@@ -1545,6 +1545,21 @@ static void do_phase1_am_packet2(struct sa_block *s, const char *shared_key)
 						default:
 							break;
 						}
+						switch (s->ike.md_algo) {
+						case GCRY_MD_MD5:
+							if (!opt_weak_authentication) {
+								const char *name_hash = get_algo(SUPP_ALGO_HASH, SUPP_ALGO_IKE_SA,
+																 seen_hash, NULL, 0)->name;
+								error(1, 0, "Peer has selected %s as authentication method.\n"
+									  "This algorithm is considered too weak today.\n"
+									  "If your vpn concentrator admin still insists on using %s,\n"
+									  "use the \"--enable-weak-authentication\" option.\n",
+									  name_hash, name_hash);
+							}
+							break;
+						default:
+							break;
+						}
 					}
 				}
 				break;
@@ -2824,6 +2839,21 @@ static void do_phase2_qm(struct sa_block *s)
 								  "If your vpn concentrator admin still insists on using %s,\n"
 								  "use the \"--enable-weak-encryption\" option.\n",
 								  name_enc, name_enc);
+						}
+						break;
+					default:
+						break;
+					}
+					switch (s->ipsec.md_algo) {
+					case GCRY_MD_MD5:
+						if (!opt_weak_authentication) {
+							const char *name_hash = get_algo(SUPP_ALGO_HASH, SUPP_ALGO_IPSEC_SA,
+															 seen_auth, NULL, 0)->name;
+							error(1, 0, "Peer has selected %s as authentication method.\n"
+								  "This algorithm is considered too weak today.\n"
+								  "If your vpn concentrator admin still insists on using %s,\n"
+								  "use the \"--enable-weak-authentication\" option.\n",
+								  name_hash, name_hash);
 						}
 						break;
 					default:


### PR DESCRIPTION
These commits will prevent `vpnc` from accepting SA's with weak cryptographic settings by default. These are MD5 and 3DES in addition to DES which was already avoided before. Two new options `--enable-weak-authentication` and `--enable-weak-encryption` can re-enable these methods if needed. Option `--enable-weak-encryption` supersedes `--enable-1des` which is now deprecated.