### PR TITLE
Fix `-Wreserved-macro-identifier`

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -18,8 +18,8 @@
    $Id$
  */
 
-#ifndef __CONFIG_H__
-#define __CONFIG_H__
+#ifndef VPNC_CONFIG_H
+#define VPNC_CONFIG_H
 
 #include <unistd.h>
 #include <inttypes.h>
@@ -139,4 +139,4 @@ extern char *vpnc_getpass(const char *prompt);
 extern void logmsg(int priority, const char *format, ...)
 __attribute__ ((__format__ (__printf__, 2, 3)));
 
-#endif
+#endif /* VPNC_CONFIG_H */

--- a/src/crypto-gnutls.h
+++ b/src/crypto-gnutls.h
@@ -15,8 +15,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef __CRYPTO_GNUTLS_H__
-#define __CRYPTO_GNUTLS_H__
+#ifndef VPNC_CRYPTO_GNUTLS_H
+#define VPNC_CRYPTO_GNUTLS_H
 
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
@@ -26,5 +26,5 @@ typedef struct {
 	gnutls_x509_crt_t *stack;
 } crypto_ctx;
 
-#endif  /* __CRYPTO_GNUTLS_H__ */
+#endif  /* VPNC_CRYPTO_GNUTLS_H */
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -15,8 +15,8 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef __CRYPTO_H__
-#define __CRYPTO_H__
+#ifndef VPNC_CRYPTO_H
+#define VPNC_CRYPTO_H
 
 #include <stdarg.h>
 
@@ -135,5 +135,5 @@ unsigned char *crypto_decrypt_signature(crypto_ctx *ctx,
 										unsigned int padding,
 										crypto_error **error);
 
-#endif  /* __CRYPTO_H__ */
+#endif  /* VPNC_CRYPTO_H */
 

--- a/src/decrypt-utils.h
+++ b/src/decrypt-utils.h
@@ -19,10 +19,10 @@
    $Id$
  */
 
-#ifndef __DECRYPT_UTILS_H__
-#define __DECRYPT_UTILS_H__
+#ifndef VPNC_DECRYPT_UTILS_H
+#define VPNC_DECRYPT_UTILS_H
 
 extern int hex2bin(const char *str, char **bin, int *len);
 extern int deobfuscate(char *ct, int len, const char **resp, char *reslenp);
 
-#endif
+#endif /* VPNC_DECRYPT_UTILS_H */

--- a/src/dh.h
+++ b/src/dh.h
@@ -31,8 +31,8 @@
  * This code was written under funding by Ericsson Radio Systems.
  */
 
-#ifndef __DH_H__
-#define __DH_H__
+#ifndef VPNC_DH_H
+#define VPNC_DH_H
 
 #include <sys/types.h>
 
@@ -42,4 +42,4 @@ int dh_getlen(struct group *);
 int dh_create_exchange(struct group *, unsigned char *);
 int dh_create_shared(struct group *, unsigned char *, unsigned char *);
 
-#endif
+#endif /* VPNC_DH_H */

--- a/src/isakmp-pkt.h
+++ b/src/isakmp-pkt.h
@@ -19,8 +19,8 @@
    $Id$
  */
 
-#ifndef __ISAKMP_PKT_H__
-#define __ISAKMP_PKT_H__
+#ifndef VPNC_ISAKMP_PKT_H
+#define VPNC_ISAKMP_PKT_H
 #if defined(__linux__)
 #include <stdint.h>
 #endif
@@ -143,4 +143,4 @@ extern struct isakmp_packet *parse_isakmp_packet(const uint8_t * data,
 												 size_t data_len, int * reject);
 extern void test_pack_unpack(void);
 
-#endif
+#endif /* VPNC_ISAKMP_PKT_H */

--- a/src/isakmp.h
+++ b/src/isakmp.h
@@ -18,8 +18,8 @@
    $Id$
  */
 
-#ifndef __ISAKMP_H__
-#define __ISAKMP_H__
+#ifndef VPNC_ISAKMP_H
+#define VPNC_ISAKMP_H
 
 /* Flag bits for header.  */
 #define ISAKMP_FLAG_E   0x1
@@ -456,4 +456,4 @@ enum isakmp_modecfg_attrib_enum {
 	ISAKMP_XAUTH_ATTRIB_CISCOEXT_VENDOR = 0x7d88 /* strange cisco things ... need docs! */
 };
 
-#endif
+#endif /* VPNC_ISAKMP_H */

--- a/src/math_group.h
+++ b/src/math_group.h
@@ -32,8 +32,8 @@
  * This code was written under funding by Ericsson Radio Systems.
  */
 
-#ifndef __MATH_GROUP_H__
-#define __MATH_GROUP_H__
+#ifndef VPNC_MATH_GROUP_H
+#define VPNC_MATH_GROUP_H
 
 #include <gcrypt.h>
 
@@ -90,4 +90,4 @@ void group_init(void);
 void group_free(struct group *);
 struct group *group_get(int);
 
-#endif /* _MATH_GROUP_H_ */
+#endif /* VPNC_MATH_GROUP_H */

--- a/src/supp.h
+++ b/src/supp.h
@@ -19,8 +19,8 @@
    $Id$
  */
 
-#ifndef __SUPP_H__
-#define __SUPP_H__
+#ifndef VPNC_SUPP_H
+#define VPNC_SUPP_H
 
 enum supp_algo_key {
 	SUPP_ALGO_NAME,
@@ -51,4 +51,4 @@ extern const supported_algo_t *get_algo(enum algo_group what, enum supp_algo_key
 extern const supported_algo_t *get_dh_group_ike(void);
 extern const supported_algo_t *get_dh_group_ipsec(int server_setting);
 
-#endif
+#endif /* VPNC_SUPP_H */

--- a/src/sysdep.h
+++ b/src/sysdep.h
@@ -1,5 +1,5 @@
-#ifndef __SYSDEP_H__
-#define __SYSDEP_H__
+#ifndef VPNC_SYSDEP_H
+#define VPNC_SYSDEP_H
 
 /*
  * Different systems define different macros.
@@ -238,4 +238,4 @@ extern int unsetenv(const char *name);
 #endif
 
 
-#endif
+#endif /* VPNC_SYSDEP_H */

--- a/src/tunip.h
+++ b/src/tunip.h
@@ -18,8 +18,8 @@
    $Id$
  */
 
-#ifndef __TUNIP_H__
-#define __TUNIP_H__
+#ifndef VPNC_TUNIP_H
+#define VPNC_TUNIP_H
 
 #include "isakmp.h"
 
@@ -128,4 +128,4 @@ struct sa_block {
 extern int volatile do_kill;
 extern void vpnc_doit(struct sa_block *s);
 
-#endif
+#endif /* VPNC_TUNIP_H */

--- a/src/vpnc.h
+++ b/src/vpnc.h
@@ -18,8 +18,8 @@
    $Id$
  */
 
-#ifndef __VPNC_H__
-#define __VPNC_H__
+#ifndef VPNC_VPNC_H
+#define VPNC_VPNC_H
 
 #include "tunip.h"
 
@@ -30,4 +30,4 @@ void print_vid(const unsigned char *vid, uint16_t len);
 void rekey_phase1(struct sa_block *s);
 
 
-#endif
+#endif /* VPNC_VPNC_H */


### PR DESCRIPTION
* https://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html: "reserved names include [...] all identifiers regardless of use that begin with either two underscores [...]"