### PR TITLE
chore(license): remove Jolla Ltd. as a copyright holder

### DIFF
--- a/src/cisco-decrypt.c
+++ b/src/cisco-decrypt.c
@@ -3,7 +3,6 @@
   Thanks to HAL-9000@evilscientists.de for decoding and posting the algorithm!
 
   SPDX-FileCopyrightText: 2005 Maurice Massar
-  SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
   SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/config.c
+++ b/src/config.c
@@ -2,7 +2,6 @@
    IPSec VPN client compatible with Cisco equipment.
 
    SPDX-FileCopyrightText: 2004-2005 Maurice Massar
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/crypto-gnutls.c
+++ b/src/crypto-gnutls.c
@@ -2,7 +2,6 @@
    IPSec VPN client compatible with Cisco equipment.
 
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/crypto-gnutls.h
+++ b/src/crypto-gnutls.h
@@ -2,7 +2,6 @@
    IPSec VPN client compatible with Cisco equipment.
 
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/crypto-openssl.c
+++ b/src/crypto-openssl.c
@@ -2,7 +2,6 @@
    IPSec VPN client compatible with Cisco equipment.
 
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/crypto-openssl.h
+++ b/src/crypto-openssl.h
@@ -2,7 +2,6 @@
    IPSec VPN client compatible with Cisco equipment.
 
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -2,7 +2,6 @@
    IPSec VPN client compatible with Cisco equipment.
 
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/decrypt-utils.c
+++ b/src/decrypt-utils.c
@@ -4,7 +4,6 @@
    SPDX-FileCopyrightText: 2004-2007 Maurice Massar
    SPDX-FileCopyrightText: 2007 Wolfram Sang
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/decrypt-utils.h
+++ b/src/decrypt-utils.h
@@ -4,7 +4,6 @@
    SPDX-FileCopyrightText: 2004-2007 Maurice Massar
    SPDX-FileCopyrightText: 2007 Wolfram Sang
    SPDX-FileCopyrightText: 2019 Davide Pucci
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/dh.c
+++ b/src/dh.c
@@ -6,7 +6,6 @@
 /*
  * SPDX-FileCopyrightText: 1998 Niels Provos
  * SPDX-FileCopyrightText: 1999 Niklas Hallqvist
- * SPDX-FileCopyrightText: 2023 Jolla Ltd.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/src/dh.h
+++ b/src/dh.h
@@ -5,7 +5,6 @@
 
 /*
  * SPDX-FileCopyrightText: 1998 Niels Provos
- * SPDX-FileCopyrightText: 2023 Jolla Ltd.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/src/isakmp-pkt.c
+++ b/src/isakmp-pkt.c
@@ -3,7 +3,6 @@
 
    SPDX-FileCopyrightText: 2002 Geoffrey Keating
    SPDX-FileCopyrightText: 2003-2005 Maurice Massar
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/isakmp-pkt.h
+++ b/src/isakmp-pkt.h
@@ -3,7 +3,6 @@
 
    SPDX-FileCopyrightText: 2002 Geoffrey Keating
    SPDX-FileCopyrightText: 2003-2005 Maurice Massar
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/isakmp.h
+++ b/src/isakmp.h
@@ -2,7 +2,6 @@
    ISAKMP constants.
 
    SPDX-FileCopyrightText: 2002 Geoffrey Keating
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/makeman.pl
+++ b/src/makeman.pl
@@ -1,7 +1,6 @@
 #! /usr/bin/env perl
 
 # SPDX-FileCopyrightText: 2007 Wolfram Sang (wolfram@the-dreams.de)
-# SPDX-FileCopyrightText: 2023 Jolla Ltd.
 # some inspiration from help2man by Brendan O'Dea and from Perl::Critic
 
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/src/math_group.c
+++ b/src/math_group.c
@@ -6,7 +6,6 @@
 /*
  * SPDX-FileCopyrightText: 1998 Niels Provos
  * SPDX-FileCopyrightText: 1999 Niklas Hallqvist
- * SPDX-FileCopyrightText: 2023 Jolla Ltd.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/src/math_group.h
+++ b/src/math_group.h
@@ -6,7 +6,6 @@
 /*
  * SPDX-FileCopyrightText: 1998 Niels Provos
  * SPDX-FileCopyrightText: 1999 Niklas Hallqvist
- * SPDX-FileCopyrightText: 2023 Jolla Ltd.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/src/pcf2vpnc
+++ b/src/pcf2vpnc
@@ -2,7 +2,6 @@
 #
 # SPDX-FileCopyrightText: 2004 Stefan Tomanek <stefan@pico.ruhr.de>
 # SPDX-FileCopyrightText: 2006-2007 Wolfram Sang <ninja@the-dreams.de>
-# SPDX-FileCopyrightText: 2023 Jolla Ltd.
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/src/supp.c
+++ b/src/supp.c
@@ -3,7 +3,6 @@
 
    SPDX-FileCopyrightText: 2005 Maurice Massar
    SPDX-FileCopyrightText: 2006 Dan Villiom Podlaski Christiansen
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/supp.h
+++ b/src/supp.h
@@ -3,7 +3,6 @@
 
    SPDX-FileCopyrightText: 2005 Maurice Massar
    SPDX-FileCopyrightText: 2006 Dan Villiom Podlaski Christiansen
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/sysdep.c
+++ b/src/sysdep.c
@@ -6,7 +6,6 @@
    SPDX-FileCopyrightText: 1998-2000  Maxim Krasnyansky <max_mk@yahoo.com>
    SPDX-FileCopyrightText: 2007 Maurice Massar
    SPDX-FileCopyrightText: 2007 Paolo Zarpellon <paolo.zarpellon@gmail.com> (Cygwin support)
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/tap-win32.h
+++ b/src/tap-win32.h
@@ -17,7 +17,6 @@
  *  SPDX-FileCopyrightText: James Yonan
  *  SPDX-FileCopyrightText: 2002-2005 OpenVPN Solutions LLC
  *  SPDX-FileCopyrightText: 2003 Damion K. Wilson CIPE-Win32 Project
- *  SPDX-FileCopyrightText: 2023 Jolla Ltd.
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
 */

--- a/src/test-crypto.c
+++ b/src/test-crypto.c
@@ -1,7 +1,6 @@
 /*
    IPSec VPN client compatible with Cisco equipment.
 
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/tunip.c
+++ b/src/tunip.c
@@ -7,7 +7,6 @@
    SPDX-FileCopyrightText: 2005      Michael Tilstra
    SPDX-FileCopyrightText: 2006      Daniel Roethlisberger
    SPDX-FileCopyrightText: 2007      Paolo Zarpellon (tap+Cygwin support)
-   SPDX-FileCopyrightText: 2023      Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
    SPDX-License-Identifier: BSD-2-Clause

--- a/src/tunip.h
+++ b/src/tunip.h
@@ -2,7 +2,6 @@
    IPSec ESP and AH support.
 
    SPDX-FileCopyrightText: 2005 Maurice Massar
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/vpnc.c
+++ b/src/vpnc.c
@@ -5,7 +5,6 @@
    SPDX-FileCopyrightText: 2003-2005 Maurice Massar
    SPDX-FileCopyrightText: 2004 Tomas Mraz
    SPDX-FileCopyrightText: 2004 Martin von Gagern
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/vpnc.h
+++ b/src/vpnc.h
@@ -2,7 +2,6 @@
 
    SPDX-FileCopyrightText: 2002-2004 Geoffrey Keating
    SPDX-FileCopyrightText: 2002-2004 Maurice Massar
-   SPDX-FileCopyrightText: 2023 Jolla Ltd.
 
    SPDX-License-Identifier: GPL-2.0-or-later
  */


### PR DESCRIPTION
Apparently Jolla Ltd. did not provide any code changes while commit 46b8335 introduced a line like 'SPDX-FileCopyrightText: 2023 Jolla Ltd.' to almost every file under src/.