### PR TITLE
Try to make DPD less sensitive

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -349,7 +349,7 @@ static const char *config_def_udp_port(void)
 
 static const char *config_def_dpd_idle(void)
 {
-	return "300";
+	return "600";
 }
 
 static const char *config_ca_dir(void)

--- a/src/tunip.c
+++ b/src/tunip.c
@@ -955,7 +955,7 @@ static void vpnc_main_loop(struct sa_block *s)
 					time_t now = time(NULL);
 					if (s->ike.dpd_seqno != s->ike.dpd_seqno_ack) {
 						/* Wake up more often for dpd attempts */
-						select_timeout.tv_sec = 5;
+						select_timeout.tv_sec = s->ike.dpd_idle/10;
 						select_timeout.tv_usec = 0;
 						dpd_ike(s);
 						next_ike_dpd = now + s->ike.dpd_idle;
@@ -1029,8 +1029,8 @@ static void vpnc_main_loop(struct sa_block *s)
 				if (s->ike.dpd_seqno != s->ike.dpd_seqno_ack) {
 					dpd_ike(s);
 					next_ike_dpd = now + s->ike.dpd_idle;
-					if (now + 5 < next_up)
-						next_up = now + 5;
+					if (now + s->ike.dpd_idle/10 < next_up)
+						next_up = now + s->ike.dpd_idle/10;
 				}
 				else if (now >= next_ike_dpd) {
 					dpd_ike(s);


### PR DESCRIPTION
```
[lkundrak@v3.sk: this patch has been sitting in Fedora package in 2007. I don't understand the details here, but given the origin of the patch I can hazard a guess it was dealing with the Cisco IPSec VPN concentrator that Red Hat was running at the time being too keen to kill idle clients.]
```

https://bugzilla.redhat.com/show_bug.cgi?id=345281