### PR TITLE
makeman: use autodie instead of Fatal

### DIFF
--- a/src/makeman.pl
+++ b/src/makeman.pl
@@ -16,7 +16,7 @@
 
 use strict;
 use warnings;
-use Fatal    qw(open close);
+use autodie  qw(open close);
 use filetest qw(access);	# to always get errno-values on filetests
 use POSIX    qw(strftime setlocale LC_ALL);
 use File::Basename;


### PR DESCRIPTION
```
The Fatal(3pm) manual states:

  Fatal has been obsoleted by the new autodie pragma.

As far as makeman.pl is concerned, both do the exact same job.

[lkundrak@v3.sk: This patch has been sitting in Fedora's vpnc package
repository since 2013, with a comment that merely said
"Make it build". I wrote the above commit message, making a guess as to
why was it added.]
```