### PR TITLE
build: Create $(BUILDDIR) with the targets which need the directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,21 +90,21 @@ ifneq (,$(findstring Apple,$(shell $(CC) --version)))
 CFLAGS += -fstrict-aliasing -freorder-blocks -fsched-interblock
 endif
 
-all: $(BUILDDIR) $(addprefix $(BUILDDIR)/,$(BINS)) src/vpnc.8
-
-$(BUILDDIR):
-	@mkdir $@
+all: $(addprefix $(BUILDDIR)/,$(BINS)) src/vpnc.8
 
 $(BUILDDIR)/vpnc: $(OBJS) src/vpnc.o
+	@mkdir -p $(BUILDDIR)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 src/vpnc.8: src/vpnc.8.template src/makeman.pl $(VPNC)
 	./src/makeman.pl $(VPNC)
 
 $(BUILDDIR)/cisco-decrypt: src/cisco-decrypt.o src/decrypt-utils.o
+	@mkdir -p $(BUILDDIR)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(BUILDDIR)/test-crypto: src/sysdep.o src/test-crypto.o src/crypto.o $(CRYPTO_OBJS)
+	@mkdir -p $(BUILDDIR)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 .depend: $(SRCS) $(BINSRCS)


### PR DESCRIPTION
Without this patch the creation of `$(BUILDDIR)` is triggered unrelated by the all target. This only works if all's prerequisites are processed left to right in sequential order. Running the Makefile under make 4.4 (or higher) in --shuffle mode reveals the incorrect dependency by failing to generate `$(BUILDDIR)/vpnc`, `$(BUILDDIR)/cisco-decrypt` or `$(BUILDDIR)/test-crypto` due to the missing directory.
The wrong dependency becomes visible as well, moving `$(BUILDDIR)` to the end of all's prerequisites list.
See https://trofi.github.io/posts/238-new-make-shuffle-mode.html for more information.